### PR TITLE
fixed parsing issue in parsing files, added run function to scraper

### DIFF
--- a/git_scraper.py
+++ b/git_scraper.py
@@ -1,16 +1,20 @@
 import subprocess
 import re
+import time
 
 import git_dict
 
 #testing
 import json
 
+def get_project_full_path():
+	git_dict.data['project_full_path'] = str(subprocess.run('pwd', shell=True, stdout=subprocess.PIPE).stdout).replace("b\'","").replace("\\n\'","")
+
 def return_output(command):
-	return subprocess.run(command, shell=True, stdout=subprocess.PIPE, cwd=git_dict.data["project_full_path"]).stdout
+	return str(subprocess.run(command, shell=True, stdout=subprocess.PIPE, cwd=git_dict.data["project_full_path"]).stdout)
 
 def get_all_branches():
-	raw_output = str(return_output("git branch -a"))
+	raw_output = return_output("git branch -a")
 
 	git_dict.data['branches']['current'] = re.search("\* ([a-zA-Z_0-9\-]*)", raw_output).group(1)
 	git_dict.data['branches']['local'] = re.findall("\s(?! remotes) ([a-zA-Z_0-9\-]*)", raw_output)
@@ -20,25 +24,33 @@ def get_commit_diff():
 	local_output_command = "git rev-list --left-right --count " + git_dict.data['branches']['current'] + "..master"
 	remote_output_command = "git rev-list --left-right --count " + git_dict.data['branches']['current'] + "..origin/master"
 
-	local_raw_output = str(return_output(local_output_command))
-	remote_raw_output = str(return_output(remote_output_command))
+	local_raw_output = return_output(local_output_command)
+	remote_raw_output = return_output(remote_output_command)
 	
 	git_dict.data['commit_diff']['local_master'] = re.findall("(\d)", local_raw_output)
 	git_dict.data['commit_diff']['remote_master'] = re.findall("(\d)", remote_raw_output)
 
-def strip_status_extras(output):
-	output = output.replace("\\n  (use \"git reset HEAD <file>...\" to unstage)\\n","")
-	output = output.replace("\\n  (use \"git add <file>...\" to update what will be committed)\\n  (use \"git checkout -- <file>...\" to discard changes in working directory)\\n","")
-	output = output.replace("\\n  (use \"git add <file>...\" to include in what will be committed)\\n","")
-	
-	return output
-
-def parse_files(file_string):
-	return re.findall("modified:\s*(\w*.\w*)", file_string)
-
+#This is really broken- git status changes depending on whether there are unstaged, untracked, or staged file, which break the regex I had set for when all three are present
 def get_file_status():
-	raw_output = strip_status_extras(str(return_output("git status")))
+	raw_output = return_output("git status -s")
 
-	git_dict.data['files']['staged'] = parse_files(re.search("committed:(.*)Changes", raw_output).group(1))
-	git_dict.data['files']['unstaged'] = parse_files(re.search("commit:(.*)Untracked", raw_output).group(1))
-	git_dict.data['files']['untracked'] =  re.findall(r"\\t(\w*.\w*)", re.search("Untracked files:(.*)", raw_output).group(1))
+	staged = re.findall(r"\SM\s*([a-z-_A-Z.]*)", raw_output)
+	if staged is not None:
+		git_dict.data['files']['staged'] = staged
+
+	unstaged = re.findall(r"\sM\s*([a-z-_A-Z.]*)", raw_output)
+	if unstaged is not None:
+		git_dict.data['files']['unstaged'] = unstaged
+	
+	untracked = re.findall(r"\?\?\s*([a-z-_A-Z.]*)", raw_output)
+	if untracked is not None:
+		git_dict.data['files']['untracked'] = untracked
+
+def run():
+	get_project_full_path()
+	while(True):
+		get_all_branches()
+		get_commit_diff()
+		get_file_status()
+		print(json.dumps(git_dict.data, indent=2))
+		time.sleep(5)

--- a/main.py
+++ b/main.py
@@ -1,1 +1,4 @@
-# amazing code that runs perfectly goes here
+import git_scraper
+
+if __name__ == '__main__':
+	git_scraper.run()


### PR DESCRIPTION
parsing in get_file_status in the git scraper was really borked.  I used a git status -s command that was much easier to parse regardless of what status files are in.  I'm 85% sure I fixed it